### PR TITLE
Refactor tool registry

### DIFF
--- a/tests/test_core/test_registry/test_tool_registry.py
+++ b/tests/test_core/test_registry/test_tool_registry.py
@@ -4,7 +4,8 @@ from fluxion.core.registry.tool_registry import ToolRegistry, extract_function_m
 
 class TestToolRegistry(unittest.TestCase):
     def setUp(self):
-        ToolRegistry._registry = {}  # Reset registry before each test
+        self.tool_registry = ToolRegistry()
+        
 
         def example_tool(param1: int, param2: str = "default"):
             """
@@ -17,10 +18,10 @@ class TestToolRegistry(unittest.TestCase):
             return f"Received {param1} and {param2}"
 
         self.example_tool = example_tool
-        ToolRegistry.register_tool(example_tool)
+        self.tool_registry.register_tool(example_tool)
 
     def tearDown(self):
-        ToolRegistry._registry = {}  # Reset registry after each test
+        self.tool_registry.clear_registry()
 
     def test_metadata_extraction(self):
         metadata = extract_function_metadata(self.example_tool)
@@ -39,7 +40,7 @@ class TestToolRegistry(unittest.TestCase):
         self.assertEqual(metadata, expected_metadata)
 
     def test_register_tool(self):
-        tools = ToolRegistry.list_tools()
+        tools = self.tool_registry.list_tools()
         self.assertIn("example_tool", tools)
         self.assertEqual(tools["example_tool"]["name"], "example_tool")
 
@@ -53,7 +54,7 @@ class TestToolRegistry(unittest.TestCase):
                 },
             }
         }
-        result = ToolRegistry.invoke_tool_call(tool_call)
+        result = self.tool_registry.invoke_tool_call(tool_call)
         self.assertEqual(result, "Received 42 and hello")
 
     def test_invoke_tool_call_missing_argument(self):
@@ -66,7 +67,7 @@ class TestToolRegistry(unittest.TestCase):
             }
         }
         with self.assertRaises(ValueError) as context:
-            ToolRegistry.invoke_tool_call(tool_call)
+            self.tool_registry.invoke_tool_call(tool_call)
         self.assertIn("Missing required argument: param1", str(context.exception))
 
     def test_invoke_tool_call_invalid_tool(self):
@@ -79,7 +80,7 @@ class TestToolRegistry(unittest.TestCase):
             }
         }
         with self.assertRaises(ValueError) as context:
-            ToolRegistry.invoke_tool_call(tool_call)
+            self.tool_registry.invoke_tool_call(tool_call)
         self.assertIn("Tool 'non_existent_tool' is not registered.", str(context.exception))
 
     def test_invoke_tool_call_type_error(self):
@@ -93,7 +94,7 @@ class TestToolRegistry(unittest.TestCase):
             }
         }
         with self.assertRaises(TypeError) as context:
-            ToolRegistry.invoke_tool_call(tool_call)
+            self.tool_registry.invoke_tool_call(tool_call)
         self.assertIn("Argument 'param1' must be of type int.", str(context.exception))
 
 


### PR DESCRIPTION
This pull request introduces significant changes to the `ToolRegistry` and its integration with the `LLMChatAgent` in the `fluxion` core. The changes primarily focus on transitioning the `ToolRegistry` from a class-based registry to an instance-based registry, enhancing the flexibility and modularity of the tool management system.

### Core Enhancements:

* [`src/fluxion/core/llm_agent.py`](diffhunk://#diff-bcbe14c95f97ae601cf0e4e34fd4b5870abce14ea9549653ee462684fd9ee436L1-R1): Updated the `LLMChatAgent` to utilize an instance-based `ToolRegistry`, added methods for setting, getting, and registering tools, and modified the `execute` method to interact with the instance-based `ToolRegistry`. [[1]](diffhunk://#diff-bcbe14c95f97ae601cf0e4e34fd4b5870abce14ea9549653ee462684fd9ee436L1-R1) [[2]](diffhunk://#diff-bcbe14c95f97ae601cf0e4e34fd4b5870abce14ea9549653ee462684fd9ee436R55-R85) [[3]](diffhunk://#diff-bcbe14c95f97ae601cf0e4e34fd4b5870abce14ea9549653ee462684fd9ee436L80-R123) [[4]](diffhunk://#diff-bcbe14c95f97ae601cf0e4e34fd4b5870abce14ea9549653ee462684fd9ee436L111-L117)
* [`src/fluxion/core/registry/tool_registry.py`](diffhunk://#diff-ecb8324839bcb4f077684b7b16fe1a61854f2e1889e6ac7d545ca08da0ff0411L2-R2): Refactored `ToolRegistry` to be instance-based, added methods for registering, retrieving, listing, invoking tools, and clearing the registry. [[1]](diffhunk://#diff-ecb8324839bcb4f077684b7b16fe1a61854f2e1889e6ac7d545ca08da0ff0411L2-R2) [[2]](diffhunk://#diff-ecb8324839bcb4f077684b7b16fe1a61854f2e1889e6ac7d545ca08da0ff0411R43-R118) [[3]](diffhunk://#diff-ecb8324839bcb4f077684b7b16fe1a61854f2e1889e6ac7d545ca08da0ff0411L143-L150)

### Testing Enhancements:

* [`tests/test_core/test_llm_agent.py`](diffhunk://#diff-14a8b93a47eac7efb095e96b6ecf82644efa58beb2db62ebb6f690b2b69205f5L4-R5): Updated tests for `LLMChatAgent` to reflect changes in tool registration and invocation, added new tests for tool registration, duplicate tool names, and execution with various tool call scenarios. [[1]](diffhunk://#diff-14a8b93a47eac7efb095e96b6ecf82644efa58beb2db62ebb6f690b2b69205f5L4-R5) [[2]](diffhunk://#diff-14a8b93a47eac7efb095e96b6ecf82644efa58beb2db62ebb6f690b2b69205f5L87-R217)
* [`tests/test_core/test_registry/test_tool_registry.py`](diffhunk://#diff-dcbe0ceca42fa115e1e336121a078446c10d98fcfab96ccaf3d3c23bfa1993b9L7-R8): Updated tests for `ToolRegistry` to reflect instance-based changes, ensuring proper tool registration, invocation, and error handling. [[1]](diffhunk://#diff-dcbe0ceca42fa115e1e336121a078446c10d98fcfab96ccaf3d3c23bfa1993b9L7-R8) [[2]](diffhunk://#diff-dcbe0ceca42fa115e1e336121a078446c10d98fcfab96ccaf3d3c23bfa1993b9L20-R24) [[3]](diffhunk://#diff-dcbe0ceca42fa115e1e336121a078446c10d98fcfab96ccaf3d3c23bfa1993b9L42-R43) [[4]](diffhunk://#diff-dcbe0ceca42fa115e1e336121a078446c10d98fcfab96ccaf3d3c23bfa1993b9L56-R57) [[5]](diffhunk://#diff-dcbe0ceca42fa115e1e336121a078446c10d98fcfab96ccaf3d3c23bfa1993b9L69-R70) [[6]](diffhunk://#diff-dcbe0ceca42fa115e1e336121a078446c10d98fcfab96ccaf3d3c23bfa1993b9L82-R83) [[7]](diffhunk://#diff-dcbe0ceca42fa115e1e336121a078446c10d98fcfab96ccaf3d3c23bfa1993b9L96-R97)