### PR TITLE
Change python version to 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set Up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.10
 
     # Step 3: Install dependencies
     - name: Install Dependencies

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 ### **Prerequisites**
 
-- Python 3.8+
+- Python 3.10+
 - Anaconda or virtual environment setup
 - [Ollama](https://ollama.com/docs) installed for hosting LLMs
 - PyAudio

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-conda create -n fluxion-env python=3.8 -y
+conda create -n fluxion-env python=3.10 -y
 conda init
 source activate fluxion-env
 which python


### PR DESCRIPTION
This pull request includes updates to the Python version used across the project from 3.8 to 3.10. The most important changes include modifications to the CI workflow, the README file, and the environment setup script. Github actions have been migrating to Ubuntu 24.04  for the "ubuntu-latest" label(https://github.com/actions/runner-images/issues/10636)

Updates to Python version:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL25-R25): Updated the Python version from 3.8 to 3.10 in the CI workflow setup step.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L36-R36): Updated the prerequisite Python version from 3.8+ to 3.10+.
* [`scripts/setup_env.sh`](diffhunk://#diff-6071236f5f8e1a426b1a7c9660f08797b70aced93c2bad04453326246a3e3abfL4-R4): Changed the Python version from 3.8 to 3.10 in the environment setup script.