### PR TITLE
Change python version for doc github action CI to 3.11

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: 3.11
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/docs.yml` file. The change updates the Python version used in the setup step from 3.10 to 3.11.

* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL19-R19): Updated the Python version from 3.10 to 3.11.