### PR TITLE
feat: Add retry decorator utility

### DIFF
--- a/src/fluxion/utils/retry.py
+++ b/src/fluxion/utils/retry.py
@@ -1,0 +1,27 @@
+import time
+from typing import Callable
+
+def retry(attempts: int, delay: float = 0.0):
+    """
+    Retry a function call if it raises an exception.
+
+    Args:
+        attempts (int): Number of retry attempts.
+        delay (float): Delay in seconds between attempts.
+
+    Returns:
+        Callable: A decorator that retries the function.
+    """
+    def decorator(func: Callable):
+        def wrapper(*args, **kwargs):
+            last_exception = None
+            for attempt in range(attempts):
+                try:
+                    return func(*args, **kwargs)
+                except Exception as e:
+                    last_exception = e
+                    if delay > 0:
+                        time.sleep(delay)
+            raise last_exception
+        return wrapper
+    return decorator

--- a/tests/test_utils/test_retry.py
+++ b/tests/test_utils/test_retry.py
@@ -1,0 +1,33 @@
+import unittest
+from fluxion.utils.retry import retry
+
+class TestRetry(unittest.TestCase):
+    def test_successful_execution(self):
+        @retry(attempts=3)
+        def always_succeed():
+            return "success"
+
+        self.assertEqual(always_succeed(), "success")
+
+    def test_retry_on_failure(self):
+        counter = {"attempts": 0}
+
+        @retry(attempts=3)
+        def succeed_on_third_try():
+            counter["attempts"] += 1
+            if counter["attempts"] < 3:
+                raise ValueError("Failure")
+            return "success"
+
+        self.assertEqual(succeed_on_third_try(), "success")
+
+    def test_exhaust_retries(self):
+        @retry(attempts=3)
+        def always_fail():
+            raise ValueError("Failure")
+
+        with self.assertRaises(ValueError):
+            always_fail()
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request introduces a retry decorator for functions and includes unit tests to validate its behavior. The primary changes are the addition of the `retry` decorator function and the corresponding unit tests.

### New functionality:

* [`src/fluxion/utils/retry.py`](diffhunk://#diff-0741bef7bebcf904531476379175eac64fa4bb9110545029dad0526278fbd4daR1-R27): Added a `retry` decorator function that retries a function call if it raises an exception, with configurable attempts and delay between attempts.

### Unit tests:

* [`tests/test_utils/test_retry.py`](diffhunk://#diff-f23c0ae13fbd187c88666cc98b4006c3acbc4e88c22c6af7ac2f6605dfef88e0R1-R33): Added unit tests for the `retry` decorator to ensure it handles successful execution, retries on failure, and exhausts retries correctly.