### PR TITLE
fix: Remove pypi upload job from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,13 +50,6 @@ jobs:
         run: |
           python setup.py sdist bdist_wheel
 
-      - name: Publish to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          twine upload dist/*
-
       - name: Push Changes and Create Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/release.yml` file, specifically removing the step that publishes the package to PyPI.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L53-L59): Removed the step that publishes the package to PyPI, which includes removing the environment variables `TWINE_USERNAME` and `TWINE_PASSWORD` and the command `twine upload dist/*`.