### PR TITLE
fix: Fix release issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,22 +23,23 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install bump2version twine setuptools wheel
+          pip install bump2version setuptools wheel
 
       - name: Determine Version Bump
         id: version_bump
         run: |
-          git fetch --all
+          git fetch --all --tags
           LAST_TAG=$(git describe --tags --abbrev=0 || echo "0.0.0")
           echo "LAST_TAG=$LAST_TAG" >> $GITHUB_ENV
 
           if git log --pretty=format:%s "$LAST_TAG"...HEAD | grep -q '^feat'; then
-            echo "VERSION_BUMP=minor" >> $GITHUB_ENV
+            VERSION_BUMP=minor
           elif git log --pretty=format:%s "$LAST_TAG"...HEAD | grep -q '^fix'; then
-            echo "VERSION_BUMP=patch" >> $GITHUB_ENV
+            VERSION_BUMP=patch
           else
-            echo "VERSION_BUMP=patch" >> $GITHUB_ENV
+            VERSION_BUMP=patch
           fi
+          echo "VERSION_BUMP=$VERSION_BUMP" >> $GITHUB_ENV
 
       - name: Bump Version
         run: |
@@ -46,16 +47,17 @@ jobs:
         env:
           VERSION_BUMP: ${{ env.VERSION_BUMP }}
 
-      - name: Build Package
-        run: |
-          python setup.py sdist bdist_wheel
-
-      - name: Push Changes and Create Release
+      - name: Push Changes and Create Tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git push origin main
-          VERSION=$(python setup.py --version)
-          gh release create "v$VERSION" dist/* --title "Release v$VERSION" --notes "Automated release."
+          git push origin main --tags
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(git describe --tags --abbrev=0)
+          gh release create "$VERSION" --notes "Automated release for version $VERSION."


### PR DESCRIPTION
This pull request includes several updates to the release workflow in the `.github/workflows/release.yml` file. The main changes involve modifying the dependency installation, improving version bump determination, and separating the build and release steps.

Improvements to dependency installation and version bump determination:

* Removed the installation of `twine` from the dependencies list to streamline the dependencies.
* Updated the `git fetch` command to include tags, ensuring that the latest tags are fetched.
* Simplified the version bump determination by directly assigning the `VERSION_BUMP` variable and then exporting it to the environment.

Changes to build and release steps:

* Removed the `Build Package` step, which previously built the package using `setup.py`.
* Split the `Push Changes and Create Release` step into two separate steps: `Push Changes and Create Tag` and `Create GitHub Release`, improving clarity and separation of concerns.