### PR TITLE
Fix failing release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install bump2version setuptools wheel
 
+      - name: Fetch All Tags
+        run: git fetch --all --tags
+
       - name: Determine Version Bump
         id: version_bump
         run: |
-          git fetch --all --tags
           LAST_TAG=$(git describe --tags --abbrev=0 || echo "0.0.0")
           echo "LAST_TAG=$LAST_TAG" >> $GITHUB_ENV
 
@@ -47,7 +49,7 @@ jobs:
         env:
           VERSION_BUMP: ${{ env.VERSION_BUMP }}
 
-      - name: Push Changes and Create Tag
+      - name: Push Changes and Tags
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -55,9 +57,14 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git push origin main --tags
 
+      - name: Get New Version
+        id: get_version
+        run: |
+          VERSION=$(git describe --tags --abbrev=0)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION=$(git describe --tags --abbrev=0)
           gh release create "$VERSION" --notes "Automated release for version $VERSION."


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow in the `release.yml` file to improve the release process. The most important changes include fetching all tags separately, pushing tags along with changes, and retrieving the new version after pushing tags.

Improvements to the release process:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R28-L31): Added a separate step to fetch all tags before determining the version bump.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L50-L62): Renamed the step to push changes to also include pushing tags.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L50-L62): Added a new step to retrieve the new version after pushing tags to ensure the correct version is used in the GitHub release.