### PR TITLE
fix: Fix failing release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Fetch the full history, including tags
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -28,24 +30,28 @@ jobs:
       - name: Fetch All Tags
         run: git fetch --all --tags
 
-      - name: Determine Version Bump
-        id: version_bump
+      - name: Get Last Tag
+        id: last_tag
         run: |
           LAST_TAG=$(git describe --tags --abbrev=0 || echo "0.0.0")
           echo "LAST_TAG=$LAST_TAG" >> $GITHUB_ENV
+          echo "Last tag is $LAST_TAG"
 
-          if git log --pretty=format:%s "$LAST_TAG"...HEAD | grep -q '^feat'; then
-            VERSION_BUMP=minor
-          elif git log --pretty=format:%s "$LAST_TAG"...HEAD | grep -q '^fix'; then
-            VERSION_BUMP=patch
+      - name: Determine Version Bump
+        id: version_bump
+        run: |
+          if git log --pretty=format:%s ${{ env.LAST_TAG }}...HEAD | grep -q '^feat'; then
+            echo "VERSION_BUMP=minor" >> $GITHUB_ENV
+          elif git log --pretty=format:%s ${{ env.LAST_TAG }}...HEAD | grep -q '^fix'; then
+            echo "VERSION_BUMP=patch" >> $GITHUB_ENV
           else
-            VERSION_BUMP=patch
+            echo "VERSION_BUMP=patch" >> $GITHUB_ENV
           fi
-          echo "VERSION_BUMP=$VERSION_BUMP" >> $GITHUB_ENV
+          echo "Version bump determined: ${{ env.VERSION_BUMP }}"
 
       - name: Bump Version
         run: |
-          bump2version --current-version $LAST_TAG $VERSION_BUMP --allow-dirty
+          bump2version --current-version ${{ env.LAST_TAG }} ${{ env.VERSION_BUMP }} --allow-dirty
         env:
           VERSION_BUMP: ${{ env.VERSION_BUMP }}
 
@@ -58,10 +64,11 @@ jobs:
           git push origin main --tags
 
       - name: Get New Version
-        id: get_version
+        id: new_version
         run: |
           VERSION=$(git describe --tags --abbrev=0)
           echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "New version is $VERSION"
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
This pull request includes several changes to the `jobs:` section in the `.github/workflows/release.yml` file to improve the release workflow by making it more efficient and clear. The most important changes involve fetching the full history, restructuring the version bump determination, and improving the clarity of environment variable usage.

Improvements to fetching and version bump determination:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R17-R18): Added `fetch-depth: 0` to the `Checkout Code` step to fetch the full history, including tags.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L31-R54): Restructured the steps to get the last tag and determine the version bump, including adding echo statements for better clarity and debugging.

Clarification of environment variable usage:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L31-R54): Updated the `Bump Version` step to use the `${{ env.LAST_TAG }}` and `${{ env.VERSION_BUMP }}` environment variables.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L61-R71): Renamed the `id` of the `Get New Version` step to `new_version` and added an echo statement to print the new version.