### PR TITLE
feat: Add bump2version config

### DIFF
--- a/.bump2version.cfg
+++ b/.bump2version.cfg
@@ -1,0 +1,4 @@
+[bumpversion]
+current_version = 0.2.0
+commit = True
+tag = True

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           pip install bump2version setuptools wheel
 
       - name: Fetch All Tags
-        run: git fetch --all --tags
+        run: git fetch --tags
 
       - name: Get Last Tag
         id: last_tag


### PR DESCRIPTION
This pull request includes updates to the versioning and release workflow configuration files. The most important changes are:

Versioning Configuration:

* Added a new section to `.bump2version.cfg` to set up version bumping with the current version, commit, and tag settings.

Release Workflow:

* Modified the `Fetch All Tags` step in `.github/workflows/release.yml` to only fetch tags instead of all references.