### PR TITLE
fix: Add job to configure git credentials in github workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,10 +51,13 @@ jobs:
             echo "VERSION_BUMP=patch" >> $GITHUB_ENV
           fi
           echo "Version bump determined: ${{ env.VERSION_BUMP }}"
-
+      - name Setup git credentials
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Bump Version
         run: |
-          bump2version --current-version ${{ env.CLEAN_TAG }} ${{ env.VERSION_BUMP }} --allow-dirty
+          bump2version --current-version ${{ env.CLEAN_TAG }} ${{ env.VERSION_BUMP }} --allow-dirty setup.py
         env:
           VERSION_BUMP: ${{ env.VERSION_BUMP }}
 
@@ -62,8 +65,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git push origin main --tags
 
       - name: Get New Version


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/release.yml` file to improve the version bumping process and setup of git credentials.

Improvements to the version bumping process and git setup:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L54-L66): Added a step to set up git credentials before bumping the version. This ensures that the git user is correctly configured for the GitHub Actions bot.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L54-L66): Modified the `bump2version` command to specify `setup.py` as the target file for version bumping. This change ensures that the version bump is applied to the correct file.