### PR TITLE
fix: Fix release workflow syntax error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Get Last Tag
         id: last_tag
         run: |
-          LAST_TAG=$(git describe --tags --abbrev=0 || echo "0.0.0")
+          LAST_TAG=$(git describe --tags --abbrev=0 || echo "v0.0.0")
           # Remove the "v" prefix if it exists
           CLEAN_TAG=${LAST_TAG#v}
           echo "CLEAN_TAG=$CLEAN_TAG" >> $GITHUB_ENV
@@ -43,34 +43,40 @@ jobs:
       - name: Determine Version Bump
         id: version_bump
         run: |
+          VERSION_BUMP=""
           if git log --pretty=format:%s "${{ env.LAST_TAG }}"...HEAD | grep -q '^feat'; then
-            echo "VERSION_BUMP=minor" >> $GITHUB_ENV
+            VERSION_BUMP="minor"
           elif git log --pretty=format:%s "${{ env.LAST_TAG }}"...HEAD | grep -q '^fix'; then
-            echo "VERSION_BUMP=patch" >> $GITHUB_ENV
+            VERSION_BUMP="patch"
           elif git log --pretty=format:%s "${{ env.LAST_TAG }}"...HEAD | grep -q '^bug'; then
-            echo "VERSION_BUMP=major" >> $GITHUB_ENV
+            VERSION_BUMP="major"
+          fi
+
+          if [ -z "$VERSION_BUMP" ]; then
+            echo "NO_VERSION_BUMP=true" >> $GITHUB_ENV
           else
-            echo "NO_VERSION_BUMP" >> $GITHUB_ENV
+            echo "VERSION_BUMP=$VERSION_BUMP" >> $GITHUB_ENV
+          fi
 
       - name: Skip if No Version Bump
-        if: ${{ env.NO_VERSION_BUMP }}
+        if: env.NO_VERSION_BUMP == 'true'
         run: echo "No version bump required for this merge."
 
       - name: Setup Git Credentials
-        if: ${{ env.VERSION_BUMP }}
+        if: env.VERSION_BUMP
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Bump Version
-        if: ${{ env.VERSION_BUMP }}
+        if: env.VERSION_BUMP
         run: |
           bump2version --current-version ${{ env.CLEAN_TAG }} ${{ env.VERSION_BUMP }} --allow-dirty setup.py
         env:
           VERSION_BUMP: ${{ env.VERSION_BUMP }}
 
       - name: Push Changes and Create PR
-        if: ${{ env.VERSION_BUMP }}
+        if: env.VERSION_BUMP
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/release.yml` file to improve the version bump determination and handling process. The most important changes include modifying the way the last tag is retrieved, enhancing the logic for determining the version bump, and updating the conditional checks for version bump actions.

Improvements to version bump determination:

* Modified the `Get Last Tag` step to ensure the default tag format includes a "v" prefix. (`[.github/workflows/release.ymlL36-R36](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L36-R36)`)
* Enhanced the `Determine Version Bump` step to handle cases where no version bump is required by introducing a `NO_VERSION_BUMP` environment variable. (`[.github/workflows/release.ymlR46-R79](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R46-R79)`)

Updates to conditional checks:

* Updated the `Skip if No Version Bump` step to use a more explicit conditional check for the `NO_VERSION_BUMP` environment variable. (`[.github/workflows/release.ymlR46-R79](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R46-R79)`)
* Adjusted the conditional checks for the `Setup Git Credentials`, `Bump Version`, and `Push Changes and Create PR` steps to use a simplified format. (`[.github/workflows/release.ymlR46-R79](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R46-R79)`)