### PR TITLE
fix: Delete release branch once it is merged

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,10 +74,29 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git checkout -b version-bump-${{ env.VERSION_BUMP }}
-          git push origin version-bump-${{ env.VERSION_BUMP }}
+          TIMESTAMP=$(date +%s)
+          BRANCH_NAME=version-bump-${{ env.VERSION_BUMP }}-$TIMESTAMP
+          git checkout -b $BRANCH_NAME
+          git push origin $BRANCH_NAME
 
           VERSION=$(python setup.py --version)
-          gh pr create --base main --head version-bump-${{ env.VERSION_BUMP }} \
+          gh pr create --base main --head $BRANCH_NAME \
             --title "Version Bump: $VERSION" \
             --body "Automated PR to bump version to $VERSION."
+
+  cleanup:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Delete Version Bump Branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH_NAME=$(echo ${{ github.event.pull_request.head.ref }})
+          if [[ $BRANCH_NAME == version-bump-* ]]; then
+            echo "Deleting branch $BRANCH_NAME"
+            git push origin --delete $BRANCH_NAME
+          else
+            echo "Branch $BRANCH_NAME is not a version bump branch, skipping deletion."
+          fi


### PR DESCRIPTION
This pull request includes changes to the `jobs:` section in the `.github/workflows/release.yml` file to improve the version bump process and add a cleanup job. The most important changes include dynamically generating the branch name with a timestamp and adding a cleanup step to delete the version bump branch after the pull request is merged.

Improvements to version bump process:

* Dynamically generate the branch name with a timestamp to avoid conflicts. (`.github/workflows/release.yml`)

Addition of cleanup job:

* Add a cleanup job to delete the version bump branch after the pull request is merged. (`.github/workflows/release.yml`)