### PR TITLE
fix: Fix syntax error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,18 +43,23 @@ jobs:
       - name: Determine Version Bump
         id: version_bump
         run: |
-          VERSION_BUMP=""
-          if git log --pretty=format:%s "${{ env.LAST_TAG }}"...HEAD | grep -q '^feat'; then
-            echo "VERSION_BUMP=minor" >> $GITHUB_ENV
-          elif git log --pretty=format:%s "${{ env.LAST_TAG }}"...HEAD | grep -q '^fix'; then
-            echo "VERSION_BUMP=patch" >> $GITHUB_ENV
-          elif git log --pretty=format:%s "${{ env.LAST_TAG }}"...HEAD | grep -q '^bug'; then
-            echo "VERSION_BUMP=major" >> $GITHUB_ENV
-          else
-            echo "NO_VERSION_BUMP" >> $GITHUB_ENV
+        VERSION_BUMP=""
+        if git log --pretty=format:%s "${{ env.LAST_TAG }}"...HEAD | grep -q '^feat'; then
+          VERSION_BUMP=minor
+        elif git log --pretty=format:%s "${{ env.LAST_TAG }}"...HEAD | grep -q '^fix'; then
+          VERSION_BUMP=patch
+        elif git log --pretty=format:%s "${{ env.LAST_TAG }}"...HEAD | grep -q '^bug'; then
+          VERSION_BUMP=major
+        fi
+        
+        if [ -z "$VERSION_BUMP" ]; then
+          echo "NO_VERSION_BUMP=true" >> $GITHUB_ENV
+        else
+          echo "VERSION_BUMP=$VERSION_BUMP" >> $GITHUB_ENV
+        fi
 
       - name: Skip if No Version Bump
-        if: ${{ env.NO_VERSION_BUMP }}
+        if: env.NO_VERSION_BUMP == 'true'
         run: echo "No version bump required for this merge."
 
       - name: Setup Git Credentials


### PR DESCRIPTION
This pull request includes changes to the `jobs:` section in the `.github/workflows/release.yml` file to improve the version bump logic and handling of no version bump scenarios.

Improvements to version bump logic:

* Simplified the assignment of `VERSION_BUMP` by removing redundant `echo` commands and directly setting the variable.
* Added a new check to set `NO_VERSION_BUMP` to `true` if no version bump is required.
* Updated the condition for skipping the version bump to correctly check the `NO_VERSION_BUMP` environment variable.