### PR TITLE
fix: Pull main branch when running release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,11 @@ jobs:
           pip install bump2version setuptools wheel
 
       - name: Fetch All Tags
-        run: git fetch --all --tags
+        run: |
+          git fetch --all --tags
+          git checkout main
+          git pull
+
 
       - name: Get Last Tag
         id: last_tag
@@ -81,7 +85,6 @@ jobs:
         run: |
           TIMESTAMP=$(date +%s)
           BRANCH_NAME=version-bump-${{ env.VERSION_BUMP }}-$TIMESTAMP
-          git checkout main
           git checkout -b $BRANCH_NAME
           git push origin $BRANCH_NAME
 
@@ -97,9 +100,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-
-      - name: Fetch Branches
-        run: git fetch --all
 
       - name: Delete Version Bump Branch
         env:


### PR DESCRIPTION
This pull request includes several updates to the GitHub Actions workflow for the release process. The changes primarily focus on modifying the steps for fetching tags and branches, as well as ensuring the main branch is up-to-date before proceeding with further steps.

Key changes in the `.github/workflows/release.yml` file:

* Added steps to checkout and pull the latest changes from the `main` branch after fetching all tags.
* Removed the redundant `git checkout main` command before creating a new branch for the version bump.
* Removed the unnecessary step to fetch all branches after checking out the code.