### PR TITLE
Bump version: 0.3.0 → 0.3.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,4 +1,4 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.3.1
 commit = True
 tag = True

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="fluxion",
-    version="0.3.0",
+    version="0.3.1",
     description="A library for building flow-based agentic workflows.",
     author="Mitiku Yohannes",
     packages=find_packages(where="src"),


### PR DESCRIPTION
This pull request includes version updates to the project configuration files to reflect a new release.

Version updates:

* [`.bumpversion.cfg`](diffhunk://#diff-9ea6e1e3dde6d4a7e08c7c88eceed69ca745d0d2c779f8f85219b22266efff7fL2-R2): Updated the `current_version` from `0.3.0` to `0.3.1` to indicate the new version.
* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L5-R5): Updated the `version` from `0.3.0` to `0.3.1` to match the new release version.