### PR TITLE
fix: Change release last tage retrieving logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Get Last Tag
         id: last_tag
         run: |
-          LAST_TAG=$(git describe --tags --abbrev=0 || echo "0.0.0")
+          LAST_TAG=$(git tag --sort=-creatordate | head -n 1 || echo "0.0.0")
           CLEAN_TAG=${LAST_TAG#v}
           echo "CLEAN_TAG=$CLEAN_TAG" >> $GITHUB_ENV
           echo "LAST_TAG=$LAST_TAG" >> $GITHUB_ENV


### PR DESCRIPTION
This pull request includes a change to the `jobs` section in the `.github/workflows/release.yml` file to improve the method of retrieving the last tag.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L40-R40): Modified the `Get Last Tag` step to use `git tag --sort=-creatordate | head -n 1` instead of `git describe --tags --abbrev=0` for obtaining the last tag. This change ensures the most recent tag is retrieved based on creation date.