### PR TITLE
fix: Extend sphinx docs to include docs for more modules

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -34,8 +34,8 @@ jobs:
             VERSION="v${BASH_REMATCH[1]}"
             echo "VERSION=$VERSION" >> $GITHUB_ENV
           else
-            echo "Unable to determine version from PR title: $PR_TITLE"
-            exit 1
+            echo "The PR is not a version bump. No tag will be created."
+            exit 0
           fi
 
       - name: Create Tag

--- a/docs/source/fluxion.core.agent.rst
+++ b/docs/source/fluxion.core.agent.rst
@@ -1,0 +1,7 @@
+fluxion.core.agent module
+=========================
+
+.. automodule:: fluxion.core.agent
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/fluxion.core.contextual_response.rst
+++ b/docs/source/fluxion.core.contextual_response.rst
@@ -1,0 +1,7 @@
+fluxion.core.contextual\_response module
+========================================
+
+.. automodule:: fluxion.core.contextual_response
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/fluxion.core.llm_agent.rst
+++ b/docs/source/fluxion.core.llm_agent.rst
@@ -1,0 +1,7 @@
+fluxion.core.llm\_agent module
+==============================
+
+.. automodule:: fluxion.core.llm_agent
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/fluxion.core.registry.agent_registry.rst
+++ b/docs/source/fluxion.core.registry.agent_registry.rst
@@ -1,0 +1,7 @@
+fluxion.core.registry.agent\_registry module
+============================================
+
+.. automodule:: fluxion.core.registry.agent_registry
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/fluxion.core.registry.rst
+++ b/docs/source/fluxion.core.registry.rst
@@ -4,21 +4,11 @@ fluxion.core.registry package
 Submodules
 ----------
 
-fluxion.core.registry.agent\_registry module
---------------------------------------------
+.. toctree::
+   :maxdepth: 4
 
-.. automodule:: fluxion.core.registry.agent_registry
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-fluxion.core.registry.tool\_registry module
--------------------------------------------
-
-.. automodule:: fluxion.core.registry.tool_registry
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   fluxion.core.registry.agent_registry
+   fluxion.core.registry.tool_registry
 
 Module contents
 ---------------

--- a/docs/source/fluxion.core.registry.tool_registry.rst
+++ b/docs/source/fluxion.core.registry.tool_registry.rst
@@ -1,0 +1,7 @@
+fluxion.core.registry.tool\_registry module
+===========================================
+
+.. automodule:: fluxion.core.registry.tool_registry
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/fluxion.core.rst
+++ b/docs/source/fluxion.core.rst
@@ -12,29 +12,12 @@ Subpackages
 Submodules
 ----------
 
-fluxion.core.agent module
--------------------------
+.. toctree::
+   :maxdepth: 4
 
-.. automodule:: fluxion.core.agent
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-fluxion.core.contextual\_response module
-----------------------------------------
-
-.. automodule:: fluxion.core.contextual_response
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-fluxion.core.llm\_agent module
-------------------------------
-
-.. automodule:: fluxion.core.llm_agent
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   fluxion.core.agent
+   fluxion.core.contextual_response
+   fluxion.core.llm_agent
 
 Module contents
 ---------------

--- a/docs/source/fluxion.modules.api_module.rst
+++ b/docs/source/fluxion.modules.api_module.rst
@@ -1,0 +1,7 @@
+fluxion.modules.api\_module module
+==================================
+
+.. automodule:: fluxion.modules.api_module
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/fluxion.modules.ir_module.rst
+++ b/docs/source/fluxion.modules.ir_module.rst
@@ -1,0 +1,7 @@
+fluxion.modules.ir\_module module
+=================================
+
+.. automodule:: fluxion.modules.ir_module
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/fluxion.modules.llm_modules.rst
+++ b/docs/source/fluxion.modules.llm_modules.rst
@@ -1,0 +1,7 @@
+fluxion.modules.llm\_modules module
+===================================
+
+.. automodule:: fluxion.modules.llm_modules
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/fluxion.modules.rag_module.rst
+++ b/docs/source/fluxion.modules.rag_module.rst
@@ -1,0 +1,7 @@
+fluxion.modules.rag\_module module
+==================================
+
+.. automodule:: fluxion.modules.rag_module
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/fluxion.modules.rst
+++ b/docs/source/fluxion.modules.rst
@@ -4,37 +4,13 @@ fluxion.modules package
 Submodules
 ----------
 
-fluxion.modules.api\_module module
-----------------------------------
+.. toctree::
+   :maxdepth: 4
 
-.. automodule:: fluxion.modules.api_module
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-fluxion.modules.ir\_module module
----------------------------------
-
-.. automodule:: fluxion.modules.ir_module
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-fluxion.modules.llm\_modules module
------------------------------------
-
-.. automodule:: fluxion.modules.llm_modules
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-fluxion.modules.rag\_module module
-----------------------------------
-
-.. automodule:: fluxion.modules.rag_module
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   fluxion.modules.api_module
+   fluxion.modules.ir_module
+   fluxion.modules.llm_modules
+   fluxion.modules.rag_module
 
 Module contents
 ---------------

--- a/docs/source/fluxion.perception.perception.rst
+++ b/docs/source/fluxion.perception.perception.rst
@@ -1,0 +1,7 @@
+fluxion.perception.perception module
+====================================
+
+.. automodule:: fluxion.perception.perception
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/fluxion.perception.rst
+++ b/docs/source/fluxion.perception.rst
@@ -4,13 +4,10 @@ fluxion.perception package
 Submodules
 ----------
 
-fluxion.perception.perception module
-------------------------------------
+.. toctree::
+   :maxdepth: 4
 
-.. automodule:: fluxion.perception.perception
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   fluxion.perception.perception
 
 Module contents
 ---------------

--- a/docs/source/fluxion.utils.audio_utils.rst
+++ b/docs/source/fluxion.utils.audio_utils.rst
@@ -1,0 +1,7 @@
+fluxion.utils.audio\_utils module
+=================================
+
+.. automodule:: fluxion.utils.audio_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/fluxion.utils.retry.rst
+++ b/docs/source/fluxion.utils.retry.rst
@@ -1,0 +1,7 @@
+fluxion.utils.retry module
+==========================
+
+.. automodule:: fluxion.utils.retry
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/fluxion.utils.rst
+++ b/docs/source/fluxion.utils.rst
@@ -4,21 +4,11 @@ fluxion.utils package
 Submodules
 ----------
 
-fluxion.utils.audio\_utils module
----------------------------------
+.. toctree::
+   :maxdepth: 4
 
-.. automodule:: fluxion.utils.audio_utils
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-fluxion.utils.retry module
---------------------------
-
-.. automodule:: fluxion.utils.retry
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   fluxion.utils.audio_utils
+   fluxion.utils.retry
 
 Module contents
 ---------------

--- a/docs/source/fluxion.workflows.abstract_workflow.rst
+++ b/docs/source/fluxion.workflows.abstract_workflow.rst
@@ -1,0 +1,7 @@
+fluxion.workflows.abstract\_workflow module
+===========================================
+
+.. automodule:: fluxion.workflows.abstract_workflow
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/fluxion.workflows.agent_node.rst
+++ b/docs/source/fluxion.workflows.agent_node.rst
@@ -1,0 +1,7 @@
+fluxion.workflows.agent\_node module
+====================================
+
+.. automodule:: fluxion.workflows.agent_node
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/fluxion.workflows.flyte_adapter.rst
+++ b/docs/source/fluxion.workflows.flyte_adapter.rst
@@ -1,0 +1,7 @@
+fluxion.workflows.flyte\_adapter module
+=======================================
+
+.. automodule:: fluxion.workflows.flyte_adapter
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/fluxion.workflows.rst
+++ b/docs/source/fluxion.workflows.rst
@@ -4,37 +4,13 @@ fluxion.workflows package
 Submodules
 ----------
 
-fluxion.workflows.abstract\_workflow module
--------------------------------------------
+.. toctree::
+   :maxdepth: 4
 
-.. automodule:: fluxion.workflows.abstract_workflow
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-fluxion.workflows.agent\_node module
-------------------------------------
-
-.. automodule:: fluxion.workflows.agent_node
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-fluxion.workflows.flyte\_adapter module
----------------------------------------
-
-.. automodule:: fluxion.workflows.flyte_adapter
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-fluxion.workflows.workflow\_progress\_tracker module
-----------------------------------------------------
-
-.. automodule:: fluxion.workflows.workflow_progress_tracker
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   fluxion.workflows.abstract_workflow
+   fluxion.workflows.agent_node
+   fluxion.workflows.flyte_adapter
+   fluxion.workflows.workflow_progress_tracker
 
 Module contents
 ---------------

--- a/docs/source/fluxion.workflows.workflow_progress_tracker.rst
+++ b/docs/source/fluxion.workflows.workflow_progress_tracker.rst
@@ -1,0 +1,7 @@
+fluxion.workflows.workflow\_progress\_tracker module
+====================================================
+
+.. automodule:: fluxion.workflows.workflow_progress_tracker
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
This pull request includes changes to improve the documentation structure and content, as well as a minor update to the GitHub workflow for tag creation. The most important changes include adding `automodule` directives for various modules, restructuring the documentation to use `toctree`, and updating the GitHub workflow script to handle non-version bump PRs.

Documentation improvements:

* Added `automodule` directives for several modules, including `fluxion.core.agent`, `fluxion.core.contextual_response`, `fluxion.core.llm_agent`, `fluxion.core.registry.agent_registry`, `fluxion.core.registry.tool_registry`, `fluxion.modules.api_module`, `fluxion.modules.ir_module`, `fluxion.modules.llm_modules`, `fluxion.modules.rag_module`, `fluxion.perception.perception`, `fluxion.utils.audio_utils`, `fluxion.utils.retry`, `fluxion.workflows.abstract_workflow`, and `fluxion.workflows.agent_node`. [[1]](diffhunk://#diff-6e4f65455c86b2b2f82a8d76947281b3abd1a50e32e4fa05e7c3c4c756bff586R1-R7) [[2]](diffhunk://#diff-44193ac29ae114288cbce74802ef433bf10d05b9f683565bb305b9cae89af4b2R1-R7) [[3]](diffhunk://#diff-97d003b1ec3bff9b956e786c1d91938c270153bcab4ada0592b765570713ccc8R1-R7) [[4]](diffhunk://#diff-fa526f20641c32f85cff5e75272487fcb82284178b53cf34c73d78d22aeaab43R1-R7) [[5]](diffhunk://#diff-fc5087bb944c9006734498c79cd786714bbdca7c05d0d140b77e2de447420726R1-R7) [[6]](diffhunk://#diff-3721aaa8a03aae2b634add473a17636d5de73de87cdfe38f0777cee8872911f6R1-R7) [[7]](diffhunk://#diff-0ac86e4ea31752545bdde6f9eae565ea4d35c70a7a093c3773f2ccd3946b7fe4R1-R7) [[8]](diffhunk://#diff-01d6150143d430954919b004b4f9b11b555b0126b56944892759293aad05a432R1-R7) [[9]](diffhunk://#diff-804e08290af591267c41df5d66d2059703ce0022172b5686b3e09c1746811bf7R1-R7) [[10]](diffhunk://#diff-63c069ed517f548ef0c1a5d7ba460b4767335257406312a4a6fb540b35bd96deR1-R7) [[11]](diffhunk://#diff-77ac99136be833673199962832977bd037d600844214bc30275cbff204f2f930R1-R7) [[12]](diffhunk://#diff-7af2d44701d4badee41ba7523f84959be2f2ddbf9ca58258f93d3d0bba5ede93R1-R7) [[13]](diffhunk://#diff-776fce8b6cb2422437e9c32fa62b100ed1dc092c318b6cf52350c5a0bc1d7db3R1-R7) [[14]](diffhunk://#diff-c989534b396ef0484fd43722168cd8858dbbddd97ec4ead33bf0f75a9b01da74R1-R7)

* Restructured the documentation to use `toctree` for better organization and navigation, affecting files such as `fluxion.core.rst`, `fluxion.core.registry.rst`, `fluxion.modules.rst`, `fluxion.perception.rst`, and `fluxion.utils.rst`. [[1]](diffhunk://#diff-23069c019f4b01d82b418667538c480508c653483ad2edeb9273dd03c49887c2L15-R20) [[2]](diffhunk://#diff-094798a9c3301d689e26aac3fa403708918396ef2e24bf7e0050e539bffdeca6L7-R11) [[3]](diffhunk://#diff-1fe41e038e961d2ad476929038b94b118aa3cf0d72a0fcba16adaca4d5f6e2bfL7-R13) [[4]](diffhunk://#diff-aff8150274b08f7f8107d9ad27bd2d341b52a3e41b7a88491190c612fcf39790L7-R10) [[5]](diffhunk://#diff-05852d8dd8f9fea9c91e854c1aab887152427db3904e59dc4e0b940a07cea28aL7-R11)

GitHub workflow update:

* Updated the `create-tag.yml` workflow script to handle non-version bump PRs by changing the exit status and message when the PR is not a version bump.