### PR TITLE
fix: Fix create-tag workflow issue

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -43,6 +43,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Creating tag $VERSION"
-          git tag $VERSION
-          gh 
+          git tag -a $VERSION -m "Release $VERSION"
+          git push origin --tags $VERSION
           


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/create-tag.yml` file to improve the tagging process in the CI/CD workflow.

* [`.github/workflows/create-tag.yml`](diffhunk://#diff-4e5f412119c494026156fa6655c510219e2ff47ec4500abecd99a049fbf1495aL46-R47): Modified the `git tag` command to include an annotation with a message and changed the `git push` command to push the tags to the origin.