### PR TITLE
fix: Add github credentials config in create-tag workflow

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -22,6 +22,12 @@ jobs:
         with:
           python-version: 3.11
 
+      - name: Setup Git Credentials
+        if: ${{ env.VERSION_BUMP != '' }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Fetch All Tags
         run: git fetch --tags
 
@@ -30,19 +36,21 @@ jobs:
         run: |
           # Extract version from PR title (assuming it starts with "Version Bump: vX.Y.Z")
           PR_TITLE="${{ github.event.pull_request.title }}"
-          if [[ "$PR_TITLE" =~ Version\ Bump:\ ([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+          if [[ "$PR_TITLE" =~ Version\ Bump:\ v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
             VERSION="v${BASH_REMATCH[1]}"
             echo "VERSION=$VERSION" >> $GITHUB_ENV
+            echo "::set-output name=version_bump::true"
           else
             echo "The PR is not a version bump. No tag will be created."
             exit 0
           fi
 
       - name: Create Tag
+        if: steps.version.outputs.version_bump == 'true' && env.create_tag == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ env.VERSION }}
         run: |
           echo "Creating tag $VERSION"
           git tag -a $VERSION -m "Release $VERSION"
           git push origin --tags $VERSION
-          


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow for creating tags. The changes aim to improve the automation process by setting up Git credentials and adding conditional checks for version bumps.

Key changes:

* [`.github/workflows/create-tag.yml`](diffhunk://#diff-4e5f412119c494026156fa6655c510219e2ff47ec4500abecd99a049fbf1495aR25-R30): Added a step to set up Git credentials if a version bump is detected.
* [`.github/workflows/create-tag.yml`](diffhunk://#diff-4e5f412119c494026156fa6655c510219e2ff47ec4500abecd99a049fbf1495aL33-L48): Modified the version extraction logic to include the "v" prefix and set an output variable to indicate a version bump.
* [`.github/workflows/create-tag.yml`](diffhunk://#diff-4e5f412119c494026156fa6655c510219e2ff47ec4500abecd99a049fbf1495aL33-L48): Added conditional checks to ensure tags are created only when a version bump is detected and the `create_tag` environment variable is set to true.