### PR TITLE
fix: Fix creat tag workflows bumped version check logic

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -34,9 +34,9 @@ jobs:
       - name: Determine Version
         id: version
         run: |
-          # Extract version from PR title (assuming it starts with "Version Bump: vX.Y.Z")
+          # Extract version from PR title (assuming it starts with "Version Bump: X.Y.Z")
           PR_TITLE="${{ github.event.pull_request.title }}"
-          if [[ "$PR_TITLE" =~ Version\ Bump:\ v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+          if [[ "$PR_TITLE" =~ Version\ Bump:\ ([0-9]+\.[0-9]+\.[0-9]+) ]]; then
             VERSION="v${BASH_REMATCH[1]}"
             echo "VERSION=$VERSION" >> $GITHUB_ENV
             echo "::set-output name=version_bump::true"


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/create-tag.yml` file. The change updates the script to correctly extract the version number from the pull request title by removing the unnecessary "v" character in the regex pattern.

* [`.github/workflows/create-tag.yml`](diffhunk://#diff-4e5f412119c494026156fa6655c510219e2ff47ec4500abecd99a049fbf1495aL37-R39): Modified the regex pattern to extract the version number from the pull request title by assuming it starts with "Version Bump: X.Y.Z" instead of "Version Bump: vX.Y.Z".