### PR TITLE
fix: Minor changes to create-tag workflow

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -23,7 +23,6 @@ jobs:
           python-version: 3.11
 
       - name: Setup Git Credentials
-        if: ${{ env.VERSION_BUMP != '' }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/create-tag.yml` file. The change removes the conditional check for setting up Git credentials. 

* [`.github/workflows/create-tag.yml`](diffhunk://#diff-4e5f412119c494026156fa6655c510219e2ff47ec4500abecd99a049fbf1495aL26): Removed the conditional `if` statement for setting up Git credentials.