### PR TITLE
Add script to remove merged branches from local

### DIFF
--- a/scripts/remove_deprecated_branches.sh
+++ b/scripts/remove_deprecated_branches.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Copied from https://stackoverflow.com/a/28464339/5825953
+# Remove all branches that are already merged into the currently checked out branch
+
+git branch --merged >/tmp/merged-branches && \
+sed -i '/main/d' /tmp/merged-branches && \
+sed -i '/master/d' /tmp/merged-branches && \
+sed -i '/gh-pages/d' /tmp/merged-branches && \
+sed -i '/release-*/d' /tmp/merged-branches && \
+
+nano /tmp/merged-branches && xargs git branch -d </tmp/merged-branches


### PR DESCRIPTION
This pull request introduces a new script to remove deprecated branches that have already been merged into the currently checked-out branch. The script is designed to help keep the repository clean by deleting branches that are no longer needed.

Key changes:

* Added a new script `remove_deprecated_branches.sh` that removes all branches merged into the current branch, except for `main`, `master`, `gh-pages`, and any branch starting with `release-`.