### PR TITLE
Add delegation agent example

### DIFF
--- a/scripts/examples/delegation_agent_example.py
+++ b/scripts/examples/delegation_agent_example.py
@@ -1,0 +1,56 @@
+from fluxion.models.message_model import Message, MessageHistory
+from fluxion.core.agents.delegation_agent import DelegationAgent
+from fluxion.core.modules.llm_modules import LLMChatModule
+from fluxion.core.agents.agent import Agent
+
+# Mock specialized agents
+class GenericAgent(Agent):
+    def execute(self, messages: MessageHistory):
+        return MessageHistory(messages=[Message(role="tool", content="Task handled by Generic Agent.")])
+
+class DataSummarizerAgent(Agent):
+
+    def execute(self, messages):
+        return MessageHistory(messages=[Message(role="tool", content="Data summarized successfully.")])
+
+class DataLoaderAgent(Agent):
+
+    def execute(self, messages):
+        return MessageHistory(messages=[Message(role="tool", content="Data loaded successfully.")])
+
+# Initialize the LLM module
+llm_chat_module = LLMChatModule(endpoint="http://localhost:11434/api/chat", model="llama3.2", timeout=120)
+
+# Initialize agents
+generic_agent = GenericAgent(name="GenericAgent")
+data_summarizer_agent = DataSummarizerAgent(name="DataSummarizer")
+data_loader_agent = DataLoaderAgent(name="DataLoader")
+
+# Initialize DelegationAgent
+delegation_agent = DelegationAgent(name="DelegationAgent", llm_module=llm_chat_module, generic_agent=generic_agent)
+
+# Add agents to delegation registry
+delegation_agent.delegate_task("Summarize the data from the sales report.", "DataSummarizer")
+delegation_agent.delegate_task("Load the data from the sales report.", "DataLoader")
+
+# Task 1: Load the dataset
+task_description = "There is dataset located at 'data/sales_report.csv' that needs to be analyzed. Load the dataset."
+messages = MessageHistory(messages=[Message(role="user", content=task_description)])
+result = delegation_agent.decide_and_delegate(messages=messages)
+print("Task: ", task_description)
+print("Delegation Result:", result[-1].content)
+
+# Task 2: Summarize the data
+task_description = "Summarize the data from the sales report."
+messages = MessageHistory(messages=[Message(role="user", content=task_description)])
+result = delegation_agent.decide_and_delegate(messages=messages)
+print("Task: ", task_description)
+print("Delegation Result:", result[-1].content)
+
+
+# Task 3: Generic task
+task_description = "Search for information on the internet. Search for Agentic AI."
+messages = MessageHistory(messages=[Message(role="user", content=task_description)])
+result = delegation_agent.decide_and_delegate(messages=messages)
+print("Task: ", task_description)
+print("Delegation Result:", result[-1].content)

--- a/scripts/run_examples.sh
+++ b/scripts/run_examples.sh
@@ -25,6 +25,10 @@ source activate fluxion-env
 # echo "Running chatbot example"
 # python scripts/examples/chatbot_example.py
 
-echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-echo "Running agent coordination example"
-python scripts/examples/agent_coordination_example.py
+# echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+# echo "Running agent coordination example"
+# python scripts/examples/agent_coordination_example.py
+
+# echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+# echo "Running delegation agent example"
+python scripts/examples/delegation_agent_example.py

--- a/src/fluxion/core/agents/delegation_agent.py
+++ b/src/fluxion/core/agents/delegation_agent.py
@@ -121,7 +121,7 @@ class DelegationAgent(LLMChatAgent):
             {
                 "task_description": metadata["task_description"],
                 "agent_name": agent_name,
-                "agent_metadata": metadata["agent_metadata"]
+                "agent_description": metadata["agent_metadata"]["description"],
             }
             for agent_name, metadata in self.delegation_registry.list_delegations()
         ]
@@ -142,8 +142,10 @@ class DelegationAgent(LLMChatAgent):
             "{\n"
             "    \"agent_name\": \"generic_agent\"\n"
             "}"
-            "Strictly adhere to the structure for successful delegation."
-            "Do not include any additional information in your response."
+            "- Strictly adhere to the structure for successful delegation.\n"
+            "- Do not include any additional information in your response.\n"
+            "- Do not assign the task to an agent if the task is not delegated to the agent.\n"
+            "- If the task is not delegated to an agent, the generic agent will handle the task."
 
         )
         initial_messages = messages


### PR DESCRIPTION
This pull request introduces a new example script for delegation agents, updates the `run_examples.sh` script to include this new example, and makes some improvements to the delegation agent's decision-making process. Below are the most important changes:

### New Example Script:

* [`scripts/examples/delegation_agent_example.py`](diffhunk://#diff-fdcae5d4f3a1069802a13c17690b1c3c27d75fa17d49f26d83da105d71c31b6bR1-R56): Added a new example script demonstrating the use of `DelegationAgent` with specialized agents like `GenericAgent`, `DataSummarizerAgent`, and `DataLoaderAgent`. This script initializes the agents, sets up tasks, and delegates them accordingly.

### Script Updates:

* [`scripts/run_examples.sh`](diffhunk://#diff-5af6b2cba47927339828ad48516ae9bd4597fe9725a42ac206a8bc0c503b57c9L28-R34): Updated the script to comment out the agent coordination example and include the new delegation agent example.

### Delegation Agent Improvements:

* [`src/fluxion/core/agents/delegation_agent.py`](diffhunk://#diff-59e7031078e0655f1924aca4e852ec3f4cd38e4b350778a8fc3e636543f3bfe1L124-R124): Modified the `decide_and_delegate` method to include `agent_description` instead of `agent_metadata` in the delegation metadata.
* [`src/fluxion/core/agents/delegation_agent.py`](diffhunk://#diff-59e7031078e0655f1924aca4e852ec3f4cd38e4b350778a8fc3e636543f3bfe1L145-R148): Updated the delegation instructions to ensure tasks are only assigned to agents if delegated, with a fallback to the generic agent if no delegation is specified.