### PR TITLE
Refactor IR modules

### DIFF
--- a/scripts/examples/rag_example.py
+++ b/scripts/examples/rag_example.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
   
     query = "Who is Robert B. Darnell? What is his lab's recent discovery?"
 
-    retrieval_module = RetrievalModule(index=index, documents=documents, endpoint=endpoint, model=model, embedding_size=384)
+    retrieval_module = RetrievalModule(indexing_module=index_module, endpoint=endpoint, model=model, embedding_size=384)
     response = retrieval_module.execute(query=query, top_k=2)
     print("Query:", query)
     print("Retrieval Response:")

--- a/scripts/run_examples.sh
+++ b/scripts/run_examples.sh
@@ -21,9 +21,9 @@ source activate fluxion-env
 # echo "Running Workflow creation example"
 # python scripts/examples/workflow_creation_example.py
 
-# echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-# echo "Running chatbot example"
-# python scripts/examples/chatbot_example.py
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+echo "Running chatbot example"
+python scripts/examples/chatbot_example.py
 
 # echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 # echo "Running agent coordination example"
@@ -31,4 +31,4 @@ source activate fluxion-env
 
 # echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 # echo "Running delegation agent example"
-python scripts/examples/delegation_agent_example.py
+# python scripts/examples/delegation_agent_example.py

--- a/src/fluxion/__init__.py
+++ b/src/fluxion/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.2.0"
+__version__ = "1.1.0-beta"
 __author__ = "Mitiku Yohannes"
 __all__ = ["fluxion"]

--- a/src/fluxion/core/modules/ir_module.py
+++ b/src/fluxion/core/modules/ir_module.py
@@ -278,13 +278,12 @@ class RetrievalModule(EmbeddingApiModule):
         response = retrieval_module.execute(query="What is the capital of France?", top_k=1)
         print(response)
     """
-    def __init__(self, index: faiss.IndexFlatIP, documents: List[str], endpoint: str, model: str = None, headers: dict = {}, timeout: int = 10, embedding_size: int = 768, batch_size: int = 4):
+    def __init__(self, indexing_module: IndexingModule, endpoint: str, model: str = None, headers: dict = {}, timeout: int = 10, embedding_size: int = 768, batch_size: int = 4):
         """
         Initialize the RetrievalModule.
 
         Args:
-            index (faiss.IndexFlatIP): The FAISS index to use for retrieval.
-            documents (List[str]): The list of documents corresponding to the index.
+            indexing_module (IndexingModule): The indexing module containing the FAISS index.
             endpoint (str): The API endpoint URL.
             model (str, optional): The embedding model name.
             headers (dict, optional): Headers to include in API requests. Defaults to an empty dictionary.
@@ -293,8 +292,7 @@ class RetrievalModule(EmbeddingApiModule):
             batch_size (int, optional): Batch size for encoding queries. Defaults to 4.
         """
         super().__init__(endpoint, model, headers, timeout, embedding_size=embedding_size, batch_size=batch_size, documents_key="query")
-        self.index = index
-        self.documents = documents
+        self.indexing_module = indexing_module
         self.logger = logging.getLogger(__name__)
 
 
@@ -328,9 +326,9 @@ class RetrievalModule(EmbeddingApiModule):
             List[str]: The retrieved documents.
         """
         query_embedding = super().execute(query=query)
-        distances, indices = self.index.search(query_embedding, top_k)
+        distances, indices = self.indexing_module.index.search(query_embedding, top_k)
                 
-        return [self.documents[i] for i in indices[0] if i < len(self.documents)]
+        return [self.indexing_module.documents[i] for i in indices[0] if i < len(self.indexing_module.documents)]
     def execute(self, *args, **kwargs) -> List[str]:
         """
         Execute the retrieval process.

--- a/tests/test_core/test_modules/test_ir_module.py
+++ b/tests/test_core/test_modules/test_ir_module.py
@@ -22,8 +22,11 @@ class TestRetrievalModule(unittest.TestCase):
         mock_index = faiss.IndexFlatIP(4)
         mock_index.add(np.array([[0.1, 0.2, 0.3, 0.4]]))
         documents = ["Test document"]
+        indexing_module = IndexingModule(endpoint="http://mock-endpoint", model="mock-model", embedding_size=4)
+        indexing_module.index = mock_index
+        indexing_module.documents = documents
         
-        module = RetrievalModule(index=mock_index, documents=documents, endpoint="http://mock-endpoint", model="mock-model", embedding_size=4)
+        module = RetrievalModule(indexing_module=indexing_module, documents=documents, endpoint="http://mock-endpoint", model="mock-model", embedding_size=4)
         module.encode_document = Mock(return_value=np.array([[0.1, 0.2, 0.3, 0.4]]))  # Mock embedding generation
         
         results = module.execute(query="Test query", top_k=1)


### PR DESCRIPTION
This pull request includes several changes to the `fluxion` project, primarily focused on updating the `RetrievalModule` to use an `IndexingModule` and adjusting related scripts and tests accordingly. Additionally, it includes a version update for the project. The most important changes are summarized below:

### Updates to `RetrievalModule`:

* [`src/fluxion/core/modules/ir_module.py`](diffhunk://#diff-18418bfbe25f2e6dccdf82212b2f7b97edaf2d6a076b59d612ab2875d162e4f6L281-R286): Modified the `RetrievalModule` to use an `IndexingModule` instead of separate `index` and `documents` parameters. This change affects the `__init__`, `retrieve`, and `execute` methods. [[1]](diffhunk://#diff-18418bfbe25f2e6dccdf82212b2f7b97edaf2d6a076b59d612ab2875d162e4f6L281-R286) [[2]](diffhunk://#diff-18418bfbe25f2e6dccdf82212b2f7b97edaf2d6a076b59d612ab2875d162e4f6L296-R295) [[3]](diffhunk://#diff-18418bfbe25f2e6dccdf82212b2f7b97edaf2d6a076b59d612ab2875d162e4f6L331-R331)

### Script adjustments:

* [`scripts/examples/rag_example.py`](diffhunk://#diff-ccb226923833ee650e9bf56b62dbc92583d9c74cbeab163b357c5146c98f1395L31-R31): Updated the instantiation of `RetrievalModule` to use the new `indexing_module` parameter.
* [`scripts/run_examples.sh`](diffhunk://#diff-5af6b2cba47927339828ad48516ae9bd4597fe9725a42ac206a8bc0c503b57c9L24-R34): Uncommented and enabled the execution of the `chatbot_example.py` script.

### Version update:

* [`src/fluxion/__init__.py`](diffhunk://#diff-42ea63796ed7d959ee8d50558cfa888ef9264d93a45b8dab14c7cbfd085746a9L1-R1): Updated the version of the `fluxion` project from `0.2.0` to `1.1.0-beta`.

### Test adjustments:

* [`tests/test_core/test_modules/test_ir_module.py`](diffhunk://#diff-e2e20505008efea3d8ae1b01cb4db26257cc56a979fa72a10d23f4663c4dac4eR25-R29): Updated the `test_retrieval` method to create and use an `IndexingModule` for testing the `RetrievalModule`.