### PR TITLE
Fix failing unit tests issue

### DIFF
--- a/tests/test_core/test_modules/test_ir_module.py
+++ b/tests/test_core/test_modules/test_ir_module.py
@@ -26,7 +26,7 @@ class TestRetrievalModule(unittest.TestCase):
         indexing_module.index = mock_index
         indexing_module.documents = documents
         
-        module = RetrievalModule(indexing_module=indexing_module, documents=documents, endpoint="http://mock-endpoint", model="mock-model", embedding_size=4)
+        module = RetrievalModule(indexing_module=indexing_module, endpoint="http://mock-endpoint", model="mock-model", embedding_size=4)
         module.encode_document = Mock(return_value=np.array([[0.1, 0.2, 0.3, 0.4]]))  # Mock embedding generation
         
         results = module.execute(query="Test query", top_k=1)


### PR DESCRIPTION
This pull request includes a change to the `tests/test_core/test_modules/test_ir_module.py` file. The change modifies the instantiation of the `RetrievalModule` within the `test_retrieval` method by removing the `documents` parameter. 

* [`tests/test_core/test_modules/test_ir_module.py`](diffhunk://#diff-e2e20505008efea3d8ae1b01cb4db26257cc56a979fa72a10d23f4663c4dac4eL29-R29): Removed the `documents` parameter from the `RetrievalModule` instantiation in the `test_retrieval` method.