### PR TITLE
Write the pytest output to both file and std

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Run Unit Tests with Coverage
       id: test
       run: |
-        pytest tests/ --cov=src --cov-report=term --cov-report=term-missing > coverage_output.txt
+        pytest tests/ --cov=src --cov-report=term --cov-report=term-missing | tee coverage_output.txt
 
     # Step 5: Post Coverage to PR
     - name: Post Coverage Comment


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/ci.yml` file. The change ensures that the output of the unit tests with coverage is displayed in the terminal as well as saved to a file.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL40-R40): Modified the command to run unit tests with coverage to use `tee` so that the output is both displayed in the terminal and saved to `coverage_output.txt`.