### PR TITLE
Create release-v1.1.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0-beta
+current_version = 1.0.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="fluxion-ai-python",
-    version="1.1.0-beta",
+    version="1.1.0",
     author="Mitiku Yohannes",
     author_email="se.mitiku.yohannes@gmail.com",
     description="A framework for orchestrating flow-based agentic workflows using LLMs.",

--- a/src/fluxion_ai/__init__.py
+++ b/src/fluxion_ai/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.1.0-beta"
+__version__ = "1.1.0"
 __author__ = "Mitiku Yohannes"
 __all__ = ["fluxion"]


### PR DESCRIPTION
This pull request includes changes to update the version number from beta to the final release in various configuration and source files.

Version updates:

* [`.bumpversion.cfg`](diffhunk://#diff-9ea6e1e3dde6d4a7e08c7c88eceed69ca745d0d2c779f8f85219b22266efff7fL2-R2): Updated `current_version` from `1.0.0-beta` to `1.0.0`.
* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L5-R5): Updated the `version` from `1.1.0-beta` to `1.1.0`.
* [`src/fluxion_ai/__init__.py`](diffhunk://#diff-6e03288661ad9feafd88408b95e4dc8b22cc6cbaaadce1ecad16b2204909ecdeL1-R1): Updated `__version__` from `1.1.0-beta` to `1.1.0`.