### PR TITLE
Fix workflow creation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,8 +296,11 @@ from fluxion_ai.models.message_model import Message, MessageHistory
 class CustomWorkflow(AbstractWorkflow):
     def define_workflow(self):
         module = LLMChatModule(endpoint="http://localhost:11434/api/chat", model="llama3.2")
-        node1 = AgentNode(name="Node1", agent=LLMChatAgent("Agent1", llm_module=module))
-        node2 = AgentNode(name="Node2", agent=LLMChatAgent("Agent2", llm_module=module))
+        agent1 = LLMChatAgent("Agent1", llm_module=module)
+        agent2 = LLMChatAgent("Agent2", llm_module=module)
+        node1 = AgentNode(name="Node1", agent=agent1)
+        node2 = AgentNode(name="Node2", agent=agent2, dependencies=[node1], inputs={"messages": "Node1"})
+        
         self.add_node(node1)
         self.add_node(node2)
 

--- a/src/fluxion_ai/workflows/abstract_workflow.py
+++ b/src/fluxion_ai/workflows/abstract_workflow.py
@@ -121,12 +121,10 @@ class AbstractWorkflow(ABC):
             visit(node_name)
 
         for node in self.nodes.values():
-            for input_key, source in node.inputs.items():
-                node_name, output_name = source.split(".")
+            for input_key, node_name in node.inputs.items():
+
                 if node_name not in self.nodes:
                     raise ValueError(f"Input '{input_key}' references non-existent node '{node_name}'.")
-                if output_name not in self.nodes[node_name].outputs:
-                    raise ValueError(f"Input '{input_key}' references non-existent output '{output_name}' in node '{node_name}'.")
     
     def _validate_inputs_and_outputs(self):
         """
@@ -135,19 +133,13 @@ class AbstractWorkflow(ABC):
         Raises:
             ValueError: If inputs reference non-existent outputs or there are missing inputs.
         """
-        available_outputs = set(self.initial_inputs.keys())
 
         for node in self.nodes.values():
             # Check if inputs are resolved
-            for input_key, source in node.inputs.items():
-                node_name, output_name = source.split(".")
+            for input_key, node_name in node.inputs.items():
                 if node_name not in self.nodes and node_name != "workflow_input":
                     raise ValueError(f"Input '{input_key}' references non-existent node '{node_name}'.")
-                if node_name != "workflow_input" and output_name not in self.nodes[node_name].outputs:
-                    raise ValueError(f"Input '{input_key}' references non-existent output '{output_name}' in node '{node_name}'.")
             
-            # Add this node's outputs to available outputs
-            available_outputs.update(f"{node.name}.{output}" for output in node.outputs)
 
 
 


### PR DESCRIPTION
This pull request includes several changes to the `fluxion_ai` workflows to simplify the input-output mapping and validation processes. The most important changes include modifications to the `AgentNode` class, updates to the `_validate_inputs_and_outputs` method, and adjustments to the workflow definition in the `README.md`.

### Simplification of input-output mapping:

* [`src/fluxion_ai/workflows/agent_node.py`](diffhunk://#diff-0f955df4eda75cae083216ee8860e68ec65d1b859bac7eb47aefb1ec65109982L35-R39): Changed the `inputs` attribute to map input keys directly to node names instead of specific outputs. Removed the `outputs` attribute and related validation code from the `AgentNode` class. [[1]](diffhunk://#diff-0f955df4eda75cae083216ee8860e68ec65d1b859bac7eb47aefb1ec65109982L35-R39) [[2]](diffhunk://#diff-0f955df4eda75cae083216ee8860e68ec65d1b859bac7eb47aefb1ec65109982L48) [[3]](diffhunk://#diff-0f955df4eda75cae083216ee8860e68ec65d1b859bac7eb47aefb1ec65109982L57) [[4]](diffhunk://#diff-0f955df4eda75cae083216ee8860e68ec65d1b859bac7eb47aefb1ec65109982L71-R71) [[5]](diffhunk://#diff-0f955df4eda75cae083216ee8860e68ec65d1b859bac7eb47aefb1ec65109982L111-L119)

### Workflow validation updates:

* [`src/fluxion_ai/workflows/abstract_workflow.py`](diffhunk://#diff-aa56c4d9b9a9878532bb0a505358b71ebde62ad634d56db7ed29d33d08e48e2cL124-L129): Updated the `_validate_inputs_and_outputs` method to remove checks for specific outputs and simplify input validation. [[1]](diffhunk://#diff-aa56c4d9b9a9878532bb0a505358b71ebde62ad634d56db7ed29d33d08e48e2cL124-L129) [[2]](diffhunk://#diff-aa56c4d9b9a9878532bb0a505358b71ebde62ad634d56db7ed29d33d08e48e2cL138-L150)

### Workflow definition adjustments:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L299-R303): Modified the workflow example to reflect the changes in input-output mapping by separating agent creation from node creation and adding dependencies and inputs to nodes.